### PR TITLE
Add unittest for generate_page_summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,6 @@ To run the test suite:
 python -m unittest discover
 ```
 
-For running tests with coverage:
-```bash
-python -m pytest --cov=data_privacy_law tests/
-```
-
 ### Troubleshooting
 If having issues with the index delete the faiss_index folder and rebuild it by doing the following:
 ```bash

--- a/data_privacy_law/db_manager/pdf_parser.py
+++ b/data_privacy_law/db_manager/pdf_parser.py
@@ -58,6 +58,6 @@ def extract_text_from_pdf(pdf_path):
                 text.append(page_text)
 
     except FileNotFoundError as e:
-        print("Error reading PDF:", e)
+        raise FileNotFoundError("Error reading PDF:", e)
 
     return text

--- a/data_privacy_law/llm_manager/llm_manager.py
+++ b/data_privacy_law/llm_manager/llm_manager.py
@@ -111,18 +111,18 @@ def get_confirmation_result_chain():
         Look at the question and the answer, and make sure that the answer is correct and coherent. 
         DO NOT MENTION THAT I HAVE ASKED YOU THIS QUESTION BEFORE.
 
-        If the answer contains "Sorry, the database does not have specific information about your question" or a similar
-        phrase, state "Sorry, the database does not have specific information about your question”.
+        If the answer contains "Sorry, the database does not have specific information about your question" or a similar \
+phrase, state "Sorry, the database does not have specific information about your question”.
 
-        If the answer does not make sense, state "Sorry, the LLM cannot currently generate a good enough
-        response for this question. Please refer to the side table and see if there is anything from
-        those topics that you would like to know about."   
+        If the answer does not make sense, state "Sorry, the LLM cannot currently generate a good enough \
+response for this question. Please refer to the side table and see if there is anything from \
+those topics that you would like to know about."   
 
-        If the answer does make sense, state "The document database has an answer to your question. Here is the 
-        structured response based on TPLC's database", and then write the answer with an introduction, body 
-        and conclusion for the response. , based on the question and answer and context you were provided. 
-        DO NOT USE THE WORDS INTRODUCTION, BODY, CONCLUSION, in your response. 
-        THERE MUST BE AN INTRODUCTION AND CONCLUSION part to your response no matter what. 
+        If the answer does make sense, state "The document database has an answer to your question. Here is the \
+structured response based on TPLC's database", and then write the answer with an introduction, body \
+and conclusion for the response. , based on the question and answer and context you were provided. \
+DO NOT USE THE WORDS INTRODUCTION, BODY, CONCLUSION, in your response. \
+THERE MUST BE AN INTRODUCTION AND CONCLUSION part to your response no matter what. 
 
         Context:
         {context}

--- a/data_privacy_law/tests/test_db_manager.py
+++ b/data_privacy_law/tests/test_db_manager.py
@@ -32,54 +32,62 @@ class TestPDFExtraction(unittest.TestCase):
     and giving response in the right format.
     """
 
-    def setUp(self):
+    # def setUp(self):
+    #     """
+    #     Creating a temporary pdf file with 2 pages to test the extract pdf function"
+    #     """
+    #     self.temp_pdf_path = "pdf_created_for_testing.pdf"
+    #     playground = canvas.Canvas(self.temp_pdf_path, pagesize=letter)
+
+    #     # Creating the first page
+    #     playground.drawString(100, 750, "This is the first page in the project TPLC")
+    #     playground.showPage()
+
+    #     # Creating the second page
+    #     playground.drawString(100, 750, "Second page in the project TPLC")
+    #     playground.save()
+
+    # def tearDown(self):
+    #     """
+    #     Deleting the temporary pdf that was created in the setUp function
+    #     """
+    #     if os.path.exists(self.temp_pdf_path):
+    #         os.remove(self.temp_pdf_path)
+
+    # def test_pdf_extraction(self):
+    #     """
+    #     Passing the created pdf file to the extract_pdf_function
+    #     and then comparing the result vs expected
+    #     """
+    #     pages = extract_text_from_pdf(self.temp_pdf_path)
+
+    #     # Check that the output is a list.
+    #     self.assertIsInstance(pages, list, "The output should be a list.")
+
+    #     # Check that we have two pages.
+    #     self.assertEqual(len(pages), 2, "There should be 2 pages extracted.")
+
+    #     # Check that each page is a string.
+    #     for page in pages:
+    #         self.assertIsInstance(page, str, "Each page should be a string.")
+
+    #     # Verify that expected text appears on each page.
+    #     self.assertIn(
+    #         "This is the first page in the project TPLC",
+    #         pages[0],
+    #         "Page 1 text does not match.",
+    #     )
+    #     self.assertIn(
+    #         "Second page in the project TPLC", pages[1], "Page 2 text does not match."
+    #     )
+
+    def test_pdf_extraction_file_not_exist(self):
         """
-        Creating a temporary pdf file with 2 pages to test the extract pdf function"
+        Test Raising FileNotFoundError works properly. 
         """
-        self.temp_pdf_path = "pdf_created_for_testing.pdf"
-        playground = canvas.Canvas(self.temp_pdf_path, pagesize=letter)
-
-        # Creating the first page
-        playground.drawString(100, 750, "This is the first page in the project TPLC")
-        playground.showPage()
-
-        # Creating the second page
-        playground.drawString(100, 750, "Second page in the project TPLC")
-        playground.save()
-
-    def tearDown(self):
-        """
-        Deleting the temporary pdf that was created in the setUp function
-        """
-        if os.path.exists(self.temp_pdf_path):
-            os.remove(self.temp_pdf_path)
-
-    def test_pdf_extraction(self):
-        """
-        Passing the created pdf file to the extract_pdf_function
-        and then comparing the result vs expected
-        """
-        pages = extract_text_from_pdf(self.temp_pdf_path)
-
-        # Check that the output is a list.
-        self.assertIsInstance(pages, list, "The output should be a list.")
-
-        # Check that we have two pages.
-        self.assertEqual(len(pages), 2, "There should be 2 pages extracted.")
-
-        # Check that each page is a string.
-        for page in pages:
-            self.assertIsInstance(page, str, "Each page should be a string.")
-
-        # Verify that expected text appears on each page.
-        self.assertIn(
-            "This is the first page in the project TPLC",
-            pages[0],
-            "Page 1 text does not match.",
-        )
-        self.assertIn(
-            "Second page in the project TPLC", pages[1], "Page 2 text does not match."
-        )
+        temp_pdf_path ='/abc.pdf'
+        with self.assertRaises(FileNotFoundError):
+            extract_text_from_pdf(temp_pdf_path)
 
 
 class TestDBManager(unittest.TestCase):

--- a/data_privacy_law/tests/test_db_manager.py
+++ b/data_privacy_law/tests/test_db_manager.py
@@ -32,54 +32,54 @@ class TestPDFExtraction(unittest.TestCase):
     and giving response in the right format.
     """
 
-    # def setUp(self):
-    #     """
-    #     Creating a temporary pdf file with 2 pages to test the extract pdf function"
-    #     """
-    #     self.temp_pdf_path = "pdf_created_for_testing.pdf"
-    #     playground = canvas.Canvas(self.temp_pdf_path, pagesize=letter)
+    def setUp(self):
+        """
+        Creating a temporary pdf file with 2 pages to test the extract pdf function"
+        """
+        self.temp_pdf_path = "pdf_created_for_testing.pdf"
+        playground = canvas.Canvas(self.temp_pdf_path, pagesize=letter)
 
-    #     # Creating the first page
-    #     playground.drawString(100, 750, "This is the first page in the project TPLC")
-    #     playground.showPage()
+        # Creating the first page
+        playground.drawString(100, 750, "This is the first page in the project TPLC")
+        playground.showPage()
 
-    #     # Creating the second page
-    #     playground.drawString(100, 750, "Second page in the project TPLC")
-    #     playground.save()
+        # Creating the second page
+        playground.drawString(100, 750, "Second page in the project TPLC")
+        playground.save()
 
-    # def tearDown(self):
-    #     """
-    #     Deleting the temporary pdf that was created in the setUp function
-    #     """
-    #     if os.path.exists(self.temp_pdf_path):
-    #         os.remove(self.temp_pdf_path)
+    def tearDown(self):
+        """
+        Deleting the temporary pdf that was created in the setUp function
+        """
+        if os.path.exists(self.temp_pdf_path):
+            os.remove(self.temp_pdf_path)
 
-    # def test_pdf_extraction(self):
-    #     """
-    #     Passing the created pdf file to the extract_pdf_function
-    #     and then comparing the result vs expected
-    #     """
-    #     pages = extract_text_from_pdf(self.temp_pdf_path)
+    def test_pdf_extraction(self):
+        """
+        Passing the created pdf file to the extract_pdf_function
+        and then comparing the result vs expected
+        """
+        pages = extract_text_from_pdf(self.temp_pdf_path)
 
-    #     # Check that the output is a list.
-    #     self.assertIsInstance(pages, list, "The output should be a list.")
+        # Check that the output is a list.
+        self.assertIsInstance(pages, list, "The output should be a list.")
 
-    #     # Check that we have two pages.
-    #     self.assertEqual(len(pages), 2, "There should be 2 pages extracted.")
+        # Check that we have two pages.
+        self.assertEqual(len(pages), 2, "There should be 2 pages extracted.")
 
-    #     # Check that each page is a string.
-    #     for page in pages:
-    #         self.assertIsInstance(page, str, "Each page should be a string.")
+        # Check that each page is a string.
+        for page in pages:
+            self.assertIsInstance(page, str, "Each page should be a string.")
 
-    #     # Verify that expected text appears on each page.
-    #     self.assertIn(
-    #         "This is the first page in the project TPLC",
-    #         pages[0],
-    #         "Page 1 text does not match.",
-    #     )
-    #     self.assertIn(
-    #         "Second page in the project TPLC", pages[1], "Page 2 text does not match."
-    #     )
+        # Verify that expected text appears on each page.
+        self.assertIn(
+            "This is the first page in the project TPLC",
+            pages[0],
+            "Page 1 text does not match.",
+        )
+        self.assertIn(
+            "Second page in the project TPLC", pages[1], "Page 2 text does not match."
+        )
 
     def test_pdf_extraction_file_not_exist(self):
         """


### PR DESCRIPTION
1. add unittest for generate_page_summary
2. remove pytest block in readme
3. prompt formatting in get_confirmation_result_chain.
    - The previous way way lead the llm response The document database has an answer to your question. Here is the (some blanks) structured response based on TPLC's database